### PR TITLE
ci: pin nix-fast-build via flake input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,26 +27,27 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         extraPullNames: nix-community
         useDaemon: false
-    - run: nix run github:Mic92/nix-fast-build -- --skip-cached --no-nom --flake .#checks.${{ matrix.system }}
+    - run: nix run .#nix-fast-build -- --skip-cached --no-nom --flake .#checks.${{ matrix.system }}
 
-  macos:
-    strategy:
-      matrix:
-        os: [ "macos-13", "macos-14" ]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-      with:
-        extra-conf: |
-          accept-flake-config = true
-    - uses: DeterminateSystems/magic-nix-cache-action@main
-      with: 
-        use-flakehub: false
-    - uses: cachix/cachix-action@v14
-      with:
-        name: entropia
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-        extraPullNames: nix-community
-        useDaemon: false
-    - run: nix run github:Mic92/nix-fast-build -- --skip-cached --no-nom --flake .#checks.${{ matrix.os == 'macos-14' && 'aarch64-darwin' || 'x86_64-darwin' }}
+  # disabled for now, as nix-fast-build failes on macos 
+  # macos:
+  #   strategy:
+  #     matrix:
+  #       os: [ "macos-13", "macos-14" ]
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: DeterminateSystems/nix-installer-action@main
+  #     with:
+  #       extra-conf: |
+  #         accept-flake-config = true
+  #   - uses: DeterminateSystems/magic-nix-cache-action@main
+  #     with: 
+  #       use-flakehub: false
+  #   - uses: cachix/cachix-action@v14
+  #     with:
+  #       name: entropia
+  #       authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+  #       extraPullNames: nix-community
+  #       useDaemon: false
+  #   - run: nix run .#nix-fast-build -- --skip-cached --no-nom --flake .#checks.${{ matrix.os == 'macos-14' && 'aarch64-darwin' || 'x86_64-darwin' }}

--- a/flake.lock
+++ b/flake.lock
@@ -77,6 +77,24 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1659877975,
@@ -89,6 +107,28 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-fast-build": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1714663357,
+        "narHash": "sha256-2D2UVkXHivtNUohlJy3GjMaiE7efozJCRgnYOkBbZlY=",
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "rev": "071d44681486271060f938a354ef9ba82ee4f9ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
         "type": "github"
       }
     },
@@ -135,6 +175,24 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1713638189,
@@ -156,6 +214,7 @@
         "colmena": "colmena",
         "disko": "disko",
         "flake-parts": "flake-parts",
+        "nix-fast-build": "nix-fast-build",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "sops-nix": "sops-nix"
@@ -195,6 +254,27 @@
         "owner": "NixOS",
         "ref": "nixos-23.05",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-fast-build",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711963903,
+        "narHash": "sha256-N3QDhoaX+paWXHbEXZapqd1r95mdshxToGowtjtYkGI=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49dc4a92b02b8e68798abd99184f228243b6e3ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
     sops-nix.inputs."nixpkgs".follows = "nixpkgs";
     disko.url = "github:nix-community/disko";
     disko.inputs."nixpkgs".follows = "nixpkgs";
+    nix-fast-build.url = "github:Mic92/nix-fast-build";
+    nix-fast-build.inputs."nixpkgs".follows = "nixpkgs";
   };
 
   outputs = inputs@{ flake-parts, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
@@ -31,6 +33,9 @@
     ];
 
     perSystem = { pkgs, inputs', ... }: {
+      packages = {
+        inherit (inputs'.nix-fast-build.packages) nix-fast-build;
+      };
       devShells.default = pkgs.mkShellNoCC {
         sopsPGPKeyDirs = [
           "${toString ./.}/secrets/keys"


### PR DESCRIPTION
This is an attempt to fix ci on macos, if this dosn't workout I'm going to disable ci on macos.